### PR TITLE
feat: test new lifecycle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ endif
 
 build:
 	./node_modules/.bin/tsc -p tsconfig.json
-	rm -rf node_modules/@microsoft/api-extractor/node_modules/typescript || true
 	./node_modules/.bin/api-extractor run $(LOCAL_ARG) --typescript-compiler-folder ./node_modules/typescript
 
 .PHONY: build

--- a/etc/interfaces.api.md
+++ b/etc/interfaces.api.md
@@ -331,10 +331,15 @@ export namespace Lifecycle {
         stop(): Promise<void>;
         readonly components: Components;
     };
-    export function programEntryPoint<Components extends Record<string, any>>(config: {
-        main: (components: Components) => Promise<any>;
+    // (undocumented)
+    export type EntryPointParameters<Components> = ComponentBasedProgram<Components> & {
+        startComponents(): Promise<void>;
+    };
+    export type ProgramConfig<Components> = {
+        main: (program: EntryPointParameters<Components>) => Promise<any>;
         initComponents: () => Promise<Components>;
-    }): Promise<ComponentBasedProgram<Components>>;
+    };
+    export function programEntryPoint<Components extends Record<string, any>>(config: ProgramConfig<Components>): PromiseLike<ComponentBasedProgram<Components>>;
 }
 
 

--- a/etc/interfaces.api.md
+++ b/etc/interfaces.api.md
@@ -339,7 +339,12 @@ export namespace Lifecycle {
         main: (program: EntryPointParameters<Components>) => Promise<any>;
         initComponents: () => Promise<Components>;
     };
-    export function programEntryPoint<Components extends Record<string, any>>(config: ProgramConfig<Components>): PromiseLike<ComponentBasedProgram<Components>>;
+    // @deprecated
+    export function programEntryPoint<Components extends Record<string, any>>(config: {
+        main: (components: Components) => Promise<any>;
+        initComponents: () => Promise<Components>;
+    }): Promise<ComponentBasedProgram<Components>>;
+    export function run<Components extends Record<string, any>>(config: ProgramConfig<Components>): PromiseLike<ComponentBasedProgram<Components>>;
 }
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,40 +5,40 @@
   "requires": true,
   "dependencies": {
     "@microsoft/api-extractor": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.12.1.tgz",
-      "integrity": "sha512-lleLrKkqiRvOQeoRMSHQY0wl/j9SxRVd9+Btyh/WWw0kHNy7nAKyzGmejvlz2XTn13H0elJWV6C3dxhaQy4mtA==",
+      "version": "7.13.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.13.4.tgz",
+      "integrity": "sha512-Y/XxSKL9velCpd0DffSFG6kYpH47KE2eECN28ompu8CUG7jbYFUJcMgk/6R/d44vlg3V77FnF8TZ+KzTlnN9SQ==",
       "dev": true,
       "requires": {
-        "@microsoft/api-extractor-model": "7.12.1",
+        "@microsoft/api-extractor-model": "7.12.4",
         "@microsoft/tsdoc": "0.12.24",
-        "@rushstack/node-core-library": "3.35.2",
-        "@rushstack/rig-package": "0.2.9",
-        "@rushstack/ts-command-line": "4.7.8",
+        "@rushstack/node-core-library": "3.36.1",
+        "@rushstack/rig-package": "0.2.11",
+        "@rushstack/ts-command-line": "4.7.9",
         "colors": "~1.2.1",
         "lodash": "~4.17.15",
         "resolve": "~1.17.0",
         "semver": "~7.3.0",
         "source-map": "~0.6.1",
-        "typescript": "~4.0.5"
+        "typescript": "~4.1.3"
       },
       "dependencies": {
         "typescript": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
-          "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+          "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
           "dev": true
         }
       }
     },
     "@microsoft/api-extractor-model": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.12.1.tgz",
-      "integrity": "sha512-Hw+kYfUb1gt6xPWGFW8APtLVWeNEWz4JE6PbLkSHw/j+G1hAaStzgxhBx3GOAWM/G0SCDGVJOpd5YheVOyu/KQ==",
+      "version": "7.12.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.12.4.tgz",
+      "integrity": "sha512-uTLpqr48g3ICFMadIE2rQvEhA/y4Ez3m2KqQ9qtsr/weIJ/64LI+ItZTKrrKHAxP7tLgGv0FodLsy5E7cyJy/A==",
       "dev": true,
       "requires": {
         "@microsoft/tsdoc": "0.12.24",
-        "@rushstack/node-core-library": "3.35.2"
+        "@rushstack/node-core-library": "3.36.1"
       }
     },
     "@microsoft/tsdoc": {
@@ -48,9 +48,9 @@
       "dev": true
     },
     "@rushstack/node-core-library": {
-      "version": "3.35.2",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.35.2.tgz",
-      "integrity": "sha512-SPd0uG7mwsf3E30np9afCUhtaM1SBpibrbxOXPz82KWV6SQiPUtXeQfhXq9mSnGxOb3WLWoSDe7AFxQNex3+kQ==",
+      "version": "3.36.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.36.1.tgz",
+      "integrity": "sha512-YMXJ0bEpxG9AnK1shZTOay5xSIuerzxCV9sscn3xynnndBdma0oE243V79Fb25zzLfkZ1Xg9TbOXc5zmF7NYYA==",
       "dev": true,
       "requires": {
         "@types/node": "10.17.13",
@@ -73,28 +73,19 @@
       }
     },
     "@rushstack/rig-package": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.2.9.tgz",
-      "integrity": "sha512-4tqsZ/m+BjeNAGeAJYzPF53CT96TsAYeZ3Pq3T4tb1pGGM3d3TWfkmALZdKNhpRlAeShKUrb/o/f/0sAuK/1VQ==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.2.11.tgz",
+      "integrity": "sha512-6Q07ZxjnthXWSXfDy/CgjhhGaqb/0RvZbqWScLr216Cy7fuAAmjbMhE2E53+rjXOsolrS5Ep7Xcl5TQre723cA==",
       "dev": true,
       "requires": {
-        "@types/node": "10.17.13",
         "resolve": "~1.17.0",
         "strip-json-comments": "~3.1.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "10.17.13",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.13.tgz",
-          "integrity": "sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==",
-          "dev": true
-        }
       }
     },
     "@rushstack/ts-command-line": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.7.8.tgz",
-      "integrity": "sha512-8ghIWhkph7NnLCMDJtthpsb7TMOsVGXVDvmxjE/CeklTqjbbUFBjGXizJfpbEkRQTELuZQ2+vGn7sGwIWKN2uA==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.7.9.tgz",
+      "integrity": "sha512-Jq5O4t0op9xdFfS9RbUV/ZFlAFxX6gdVTY+69UFRTn9pwWOzJR0kroty01IlnDByPCgvHH8RMz9sEXzD9Qxdrg==",
       "dev": true,
       "requires": {
         "@types/argparse": "1.0.38",
@@ -115,9 +106,9 @@
       "integrity": "sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A=="
     },
     "@types/node-fetch": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
-      "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+      "version": "2.5.10",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.10.tgz",
+      "integrity": "sha512-IpkX0AasN44hgEad0gEF/V6EgR5n69VEqPEgnmoM8GsIGro3PowbWs4tR6IhxUTyPLpOn+fiGG6nrQhcmoCuIQ==",
       "requires": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -164,14 +155,19 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "form-data": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
+    },
+    "fp-future": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fp-future/-/fp-future-1.0.1.tgz",
+      "integrity": "sha512-2McmZH/KsZqlqHju9+Ox0FC7q7Knve4t6ZeKubbhAz1xpnD7hkCrP8TP5g5QbbD5bA5jBANbXf/ew4x1FjSUrw=="
     },
     "fs-extra": {
       "version": "7.0.1",
@@ -185,9 +181,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
       "dev": true
     },
     "import-lazy": {
@@ -212,9 +208,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash.get": {
@@ -239,16 +235,16 @@
       }
     },
     "mime-db": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
-      "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w=="
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
+      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw=="
     },
     "mime-types": {
-      "version": "2.1.28",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
-      "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
+      "version": "2.1.30",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
+      "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
       "requires": {
-        "mime-db": "1.45.0"
+        "mime-db": "1.47.0"
       }
     },
     "path-parse": {
@@ -267,9 +263,9 @@
       }
     },
     "semver": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
@@ -306,14 +302,14 @@
       "dev": true
     },
     "typed-url-params": {
-      "version": "1.0.0-20210105203632.commit-6fc4309",
-      "resolved": "https://registry.npmjs.org/typed-url-params/-/typed-url-params-1.0.0-20210105203632.commit-6fc4309.tgz",
-      "integrity": "sha512-IXcCBm7HYIC05OadvpztaiqaXfGhjRRgZ0soRgHaftmcRRx+pXBmlkNe3mXL83fzij/q7pzVZFleaFJ81kW/yA=="
+      "version": "1.0.0-20210105161750.commit-12a4e67",
+      "resolved": "https://registry.npmjs.org/typed-url-params/-/typed-url-params-1.0.0-20210105161750.commit-12a4e67.tgz",
+      "integrity": "sha512-gL6wyIFNvxJM26BfdfeGFIYebk5E+BYp3nrx6ukn3aP6ae/nBl7iTABj8HJv9Jr1AQ1q9FpRLD6bQEkFZ/NFHQ=="
     },
     "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
       "dev": true
     },
     "universalify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,9 +101,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.20",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.20.tgz",
-      "integrity": "sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A=="
+      "version": "14.14.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
+      "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw=="
     },
     "@types/node-fetch": {
       "version": "2.5.10",
@@ -302,9 +302,9 @@
       "dev": true
     },
     "typed-url-params": {
-      "version": "1.0.0-20210105161750.commit-12a4e67",
-      "resolved": "https://registry.npmjs.org/typed-url-params/-/typed-url-params-1.0.0-20210105161750.commit-12a4e67.tgz",
-      "integrity": "sha512-gL6wyIFNvxJM26BfdfeGFIYebk5E+BYp3nrx6ukn3aP6ae/nBl7iTABj8HJv9Jr1AQ1q9FpRLD6bQEkFZ/NFHQ=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/typed-url-params/-/typed-url-params-1.0.1.tgz",
+      "integrity": "sha512-762imXO+myoSDHD9+YxUfSmfT0yGH1j+3s9UJ6uqKkOYIwHH6/gsFo67ZoST0Ey/RSoaps1zGu1N+eiuuCxfeg=="
     },
     "typescript": {
       "version": "4.2.4",

--- a/package.json
+++ b/package.json
@@ -22,13 +22,14 @@
   },
   "homepage": "https://github.com/well-known-components/interfaces#readme",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.12.1",
-    "typescript": "^4.1.3"
+    "@microsoft/api-extractor": "^7.13.4",
+    "typescript": "^4.2.4"
   },
   "dependencies": {
-    "typed-url-params": "^1.0.0-20210105203632.commit-6fc4309",
     "@types/node": "^14.14.16",
-    "@types/node-fetch": "^2.5.7"
+    "@types/node-fetch": "^2.5.10",
+    "fp-future": "^1.0.1",
+    "typed-url-params": "^1.0.0-20210105161750.commit-12a4e67"
   },
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "typescript": "^4.2.4"
   },
   "dependencies": {
-    "@types/node": "^14.14.16",
+    "@types/node": "^14.14.37",
     "@types/node-fetch": "^2.5.10",
     "fp-future": "^1.0.1",
-    "typed-url-params": "^1.0.0-20210105161750.commit-12a4e67"
+    "typed-url-params": "^1.0.1"
   },
   "files": [
     "dist"

--- a/src/components/http-server.spec.ts
+++ b/src/components/http-server.spec.ts
@@ -13,7 +13,7 @@ it("case 1", () => {
   testAssignability<"/:a">(tx1)
 
   function testAssignability<path extends string>(x: http.PathAwareContext<{}, path>) {}
-  function testArray(x: string[]) {}
+  function testArray(x: string | string[]) {}
 })
 
 it("case 2", () => {

--- a/src/utils/lifecycle.ts
+++ b/src/utils/lifecycle.ts
@@ -181,8 +181,9 @@ export namespace Lifecycle {
     return run({
       ...config,
       async main(program) {
-        await config.main(program.components)
+        const r = await config.main(program.components)
         await program.startComponents()
+        return r
       },
     })
   }

--- a/src/utils/lifecycle.ts
+++ b/src/utils/lifecycle.ts
@@ -178,31 +178,12 @@ export namespace Lifecycle {
     main: (components: Components) => Promise<any>
     initComponents: () => Promise<Components>
   }): Promise<ComponentBasedProgram<Components>> {
-    return asyncTopLevelExceptionHanler(async () => {
-      // pick a componentInitializer
-      const componentInitializer = config.initComponents
-
-      // init ports & components
-      process.stdout.write("<<< Initializing components >>>\n")
-      const components: Components = await componentInitializer()
-
-      // wire adapters
-      process.stdout.write("<<< Wiring app >>>\n")
-      await config.main(components)
-
-      // start components & ports
-      process.stdout.write("<<< Starting components >>>\n")
-      await startComponentsLifecycle(components)
-
-      return {
-        get components() {
-          process.stderr.write("Warning: Usage of program.components is only intended for debuging reasons.\n")
-          return components
-        },
-        async stop(): Promise<void> {
-          await stopAllComponents(components)
-        },
-      }
+    return run({
+      ...config,
+      async main(program) {
+        await config.main(program.components)
+        await program.startComponents()
+      },
     })
   }
 

--- a/src/utils/lifecycle.ts
+++ b/src/utils/lifecycle.ts
@@ -1,3 +1,4 @@
+import future from "fp-future"
 import { IBaseComponent } from "../components/base-component"
 
 function stopAllComponents(components: Record<string, IBaseComponent>) {
@@ -24,8 +25,32 @@ function bindStopService(components: Record<string, IBaseComponent>) {
   })
 }
 
+async function allSettled(promises: Array<Promise<any> | PromiseLike<any>>) {
+  let mappedPromises = promises.map((p) => {
+    let r = p.then((value: any) => {
+      return {
+        status: "fulfilled",
+        value,
+      }
+    })
+
+    if ("catch" in p) {
+      r = p.catch((reason) => {
+        return {
+          status: "rejected",
+          reason,
+        }
+      })
+    }
+
+    return r
+  })
+  return Promise.all(mappedPromises)
+}
+
 // gracefully finalizes all the components on SIGTERM
 async function startComponentsLifecycle(components: Record<string, IBaseComponent>): Promise<void> {
+  process.stdout.write("<<< Starting components >>>\n")
   const pending: PromiseLike<any>[] = []
 
   let mutStarted = false
@@ -69,10 +94,9 @@ async function startComponentsLifecycle(components: Record<string, IBaseComponen
     await Promise.all(pending)
     mutStarted = true
   } catch (e) {
-    console.error(e)
     process.stderr.write("<<< Error initializing components. Stopping components and closing application. >>>\n")
-    await stopAllComponents(components)
-    process.exit(1)
+    await allSettled(pending)
+    throw e
   }
 }
 
@@ -109,39 +133,97 @@ export namespace Lifecycle {
     readonly components: Components
   }
 
+  export type EntryPointParameters<Components> = ComponentBasedProgram<Components> & {
+    startComponents(): Promise<void>
+  }
+
+  /**
+   * Program lifecycle configurations
+   */
+  export type ProgramConfig<Components> = {
+    /**
+     * async main(program)\{ .. \} entry point of the application.
+     * It should wire components together i.e. wiring routes to http-servers
+     * and listeners to kafka.
+     *
+     * The main function must also call the program.
+     *
+     * Example:
+     * ```ts
+     * async main(program) {
+     *   const { components, startComponents } = program
+     *   components.server.use(routeHandler)
+     *
+     *   // start all components, including http listener
+     *   await startComponents()
+     * }
+     * ```
+     */
+    main: (program: EntryPointParameters<Components>) => Promise<any>
+
+    /**
+     * initComponents is a function that returns the components to be used by
+     * the app.
+     */
+    initComponents: () => Promise<Components>
+  }
+
   /**
    * Program entry point, this should be the one and only top level
    * expression of your program.
    */
-  export async function programEntryPoint<Components extends Record<string, any>>(config: {
-    main: (components: Components) => Promise<any>
-    initComponents: () => Promise<Components>
-  }): Promise<ComponentBasedProgram<Components>> {
+  export function programEntryPoint<Components extends Record<string, any>>(
+    config: ProgramConfig<Components>
+  ): PromiseLike<ComponentBasedProgram<Components>> {
     return asyncTopLevelExceptionHanler(async () => {
       // pick a componentInitializer
       const componentInitializer = config.initComponents
 
       // init ports & components
       process.stdout.write("<<< Initializing components >>>\n")
-      const components: Components = await componentInitializer()
+      const components: Components = Object.freeze(await componentInitializer())
 
-      // wire adapters
-      process.stdout.write("<<< Wiring app >>>\n")
-      await config.main(components)
+      let componentsStarted: Promise<void> | undefined
 
-      // start components & ports
-      process.stdout.write("<<< Starting components >>>\n")
-      await startComponentsLifecycle(components)
-
-      return {
+      const program: EntryPointParameters<Components> = {
         get components() {
-          process.stderr.write("Warning: Usage of program.components is only intended for debuging reasons.\n")
           return components
         },
         async stop(): Promise<void> {
           await stopAllComponents(components)
         },
+        async startComponents() {
+          if (!componentsStarted) {
+            // start components & ports
+            componentsStarted = startComponentsLifecycle(components)
+          } else {
+            process.stderr.write("Warning: startComponents must be called once\n")
+          }
+
+          return componentsStarted
+        },
       }
+
+      try {
+        // wire adapters
+        process.stdout.write("<<< Wiring app >>>\n")
+        await config.main(program)
+
+        if (!componentsStarted) {
+          process.stderr.write("Warning: startComponents was not called inside programEntryPoint.main function\n")
+        } else {
+          await componentsStarted
+        }
+      } catch (e) {
+        // gracefully stop all components
+        await program.stop()
+
+        // the following throw is handled by asyncTopLevelExceptionHanler
+        // exiting the program
+        throw e
+      }
+
+      return program
     })
   }
 }


### PR DESCRIPTION
The motivation change is this:

```diff
const routeHandler = /* ... */

-async function main (components) {
+async function main ({ components, startComponents }) {

  const { server, db } = components
  server.use(routeHander)

+  // start the HTTP server and connect the DB
+  await startComponents()
}
```

It is particularly useful to create programs with a defined lifecycle, like running migrations:

```ts
async function main ({ components, startComponents, stop }) {
  // start components, connect db
  await startComponents()

  const { db } = components

  // run migrations
  await db.migrate()

  // stop program
  await stop()
}
```