### PR TITLE
chore: add fetcher interface

### DIFF
--- a/etc/interfaces.api.md
+++ b/etc/interfaces.api.md
@@ -6,7 +6,7 @@
 
 /// <reference types="node" />
 
-import type * as fetch_2 from 'node-fetch';
+import * as fetch_2 from 'node-fetch';
 import type { ParseUrlParams } from 'typed-url-params';
 import type * as stream from 'stream';
 
@@ -63,6 +63,12 @@ export interface IDatabase {
     // (undocumented)
     query<T extends Record<string, any>>(sql: string): Promise<IDatabase.IQueryResult<T>>;
 }
+
+// @alpha (undocumented)
+export type IFetchComponent = {
+    fetch(url: fetch_2.Request): Promise<fetch_2.Response>;
+    fetch(url: fetch_2.RequestInfo, init?: fetch_2.RequestInit): Promise<fetch_2.Response>;
+};
 
 // @alpha (undocumented)
 export namespace IHttpServerComponent {

--- a/src/components/fetcher.ts
+++ b/src/components/fetcher.ts
@@ -1,0 +1,9 @@
+import * as fetch from "node-fetch"
+
+/**
+ * @alpha
+ */
+export type IFetchComponent = {
+  fetch(url: fetch.Request): Promise<fetch.Response>
+  fetch(url: fetch.RequestInfo, init?: fetch.RequestInit): Promise<fetch.Response>
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export * from "./components/base-component"
 export * from "./components/status-checks"
 export * from "./components/metrics"
 export * from "./components/tracer"
+export * from "./components/fetcher"
 
 // This will be moved into a final repository once the api stabilizes
 export { Lifecycle }


### PR DESCRIPTION
Currently, the `IFetchComponent` interface used in multiple project is exported in a [test file](https://github.com/well-known-components/http-server/blob/bfe3f0a6e6d175179bcfc6b2b77cfb94f3526038/src/test-component.ts#L7) of the `WKC/http-server`.
Using the `IFetchComponent` requires importing the whole `http-server` package that might not be needed by the importer source code.
This PR aims to solve that.